### PR TITLE
Assistance with API documentation, part 1.

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -17,3 +17,19 @@ The second method expects an `id` parameter and should be expected to return the
 ```
 endpoint here
 ```
+
+## `POST` 📬
+The `POST` method enables the creation of a blog post, assuming a valid bearer token is provided, using the following data model as the body content for the request:
+
+```json
+{
+    "title": "My Fancy Dinner",
+    "url": "https://myblog.com/my-fancy-dinner",
+    "author": "tacosontitan",
+    "likes": 9001
+}
+```
+
+When the blog post is recorded successfully, a status code of `201` is returned along with the blog data above.
+
+***Note**: If an invalid token is provided, then a status code of `401` will be returned.*

--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -58,3 +58,9 @@ The `PUT` method is utilized to update an existing blog post with the following 
     "likes": 9001
 }
 ```
+
+This method can be invoked from the following endpoint:
+
+```
+endpoint here
+```

--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -46,3 +46,15 @@ endpoint here
 ```
 
 This method returns a status code of `204`.
+
+## `PUT` ♻️
+The `PUT` method is utilized to update an existing blog post with the following body data:
+
+```json
+{
+    "title": "My Fancy Dinner",
+    "url": "https://myblog.com/my-fancy-dinner",
+    "author": "tacosontitan",
+    "likes": 9001
+}
+```

--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -30,6 +30,19 @@ The `POST` method enables the creation of a blog post, assuming a valid bearer t
 }
 ```
 
-When the blog post is recorded successfully, a status code of `201` is returned along with the blog data above.
+When the blog post is recorded successfully, a status code of `201` is returned along with the blog data above. The endpoint can be invoked at:
+
+```
+endpoint here
+```
 
 ***Note**: If an invalid token is provided, then a status code of `401` will be returned.*
+
+## `DELETE` ❌
+The `DELETE` method allows the deletion of a blog by a specified `id` query parameter at the following endpoint:
+
+```
+endpoint here
+```
+
+This method returns a status code of `204`.

--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1,0 +1,19 @@
+### Blogs
+The blogs endpoint exposes the `GET`, `POST`, `DELETE` and `PUT` methods for execution and consumption.
+
+#### `GET` 📖
+There are *two* `GET` methods exposed for consumption, one is parameterless while the other has a single parameter.
+
+##### Parameterless
+The first method is parameterless and should be expected to return *all* available blogs. It can be consumed at the following endpoint:
+
+```
+endpoint here
+```
+
+##### Parameterized
+The second method expects an `id` parameter and should be expected to return the blog associated with the specified `id`. If no blog is found, then a status code of `404` is returned. It can be consumed at the following endpoint:
+
+```
+endpoint here
+```

--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1,17 +1,17 @@
-### Blogs
+# Blogs
 The blogs endpoint exposes the `GET`, `POST`, `DELETE` and `PUT` methods for execution and consumption.
 
-#### `GET` 📖
+## `GET` 📖
 There are *two* `GET` methods exposed for consumption, one is parameterless while the other has a single parameter.
 
-##### Parameterless
+### Parameterless
 The first method is parameterless and should be expected to return *all* available blogs. It can be consumed at the following endpoint:
 
 ```
 endpoint here
 ```
 
-##### Parameterized
+### Parameterized
 The second method expects an `id` parameter and should be expected to return the blog associated with the specified `id`. If no blog is found, then a status code of `404` is returned. It can be consumed at the following endpoint:
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,27 +15,7 @@ I am building a blog list application using MERN stack, that allows users to sav
 -   Run the command for testing Environment: `npm run test` or simply `npm test`
 
 ## Exposed Endpoints
-The following restful endpoints are exposed for public consumption.
-
-### Blogs
-The blogs endpoint exposes the `GET`, `POST`, `DELETE` and `PUT` methods for execution and consumption.
-
-#### `GET` 📖
-There are *two* `GET` methods exposed for consumption, one is parameterless while the other has a single parameter.
-
-##### Parameterless
-The first method is parameterless and should be expected to return *all* available blogs. It can be consumed at the following endpoint:
-
-```
-endpoint here
-```
-
-##### Parameterized
-The second method expects an `id` parameter and should be expected to return the blog associated with the specified `id`. If no blog is found, then a status code of `404` is returned. It can be consumed at the following endpoint:
-
-```
-endpoint here
-```
+There are currently *three* restful endpoints exposed for public consumption. You can read more about them [here](ENDPOINTS.md).
 
 ### What has been completed till now ?
 -   APIs for CRUD operations on a Blog

--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ The following restful endpoints are exposed for public consumption.
 The blogs endpoint exposes the `GET`, `POST`, `DELETE` and `PUT` methods for execution and consumption.
 
 #### `GET` 📖
-There are *two* `GET` methods exposed for consumption:
+There are *two* `GET` methods exposed for consumption, one is parameterless while the other has a single parameter.
 
 ##### Parameterless
 The first method is parameterless and should be expected to return *all* available blogs. It can be consumed at the following endpoint:
+
+```
+endpoint here
+```
+
+##### Parameterized
+The second method expects an `id` parameter and should be expected to return the blog associated with the specified `id`. If no blog is found, then a status code of `404` is returned. It can be consumed at the following endpoint:
 
 ```
 endpoint here

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ I am building a blog list application using MERN stack, that allows users to sav
 -   Run the command for Development Environment: `npm run dev`
 -   Run the command for testing Environment: `npm run test` or simply `npm test`
 
+## Exposed Endpoints
+The following restful endpoints are exposed for public consumption.
+
 ### What has been completed till now ?
 -   APIs for CRUD operations on a Blog
 -   API for User Login : Token generation using jwt : Password Hashing using bcrypt

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ The following restful endpoints are exposed for public consumption.
 ### Blogs
 The blogs endpoint exposes the `GET`, `POST`, `DELETE` and `PUT` methods for execution and consumption.
 
+#### `GET` 📖
+There are *two* `GET` methods exposed for consumption:
+
+##### Parameterless
+The first method is parameterless and should be expected to return *all* available blogs. It can be consumed at the following endpoint:
+
+```
+endpoint here
+```
+
 ### What has been completed till now ?
 -   APIs for CRUD operations on a Blog
 -   API for User Login : Token generation using jwt : Password Hashing using bcrypt

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ I am building a blog list application using MERN stack, that allows users to sav
 ## Exposed Endpoints
 The following restful endpoints are exposed for public consumption.
 
+### Blogs
+The blogs endpoint exposes the `GET`, `POST`, `DELETE` and `PUT` methods for execution and consumption.
+
 ### What has been completed till now ?
 -   APIs for CRUD operations on a Blog
 -   API for User Login : Token generation using jwt : Password Hashing using bcrypt


### PR DESCRIPTION
In this first pull request, I created a markdown file named `ENDPOINTS.md` which stores all of the endpoint documentation. This keeps the `README.md` file clear of bulky documentation focused primarily on developers, not consumers. The `README.md` file links to this file in a section for endpoints.

Additionally, the `blogs` endpoint has been described in the `ENDPOINTS.md` file as thoroughly as I can based on the code for the endpoint.